### PR TITLE
Use Services global variable if possible

### DIFF
--- a/api/MessagesListAdapter/implementation.js
+++ b/api/MessagesListAdapter/implementation.js
@@ -9,7 +9,9 @@
 
   // Get various parts of the WebExtension framework that we need.
   var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-  var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+  var Services = globalThis.Services || ChromeUtils.import(
+    "resource://gre/modules/Services.jsm"
+  ).Services;
 
   const listenerThreadPanes = new Set();
 


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm for recent versions.