### PR TITLE
Minimal update for Thunderbird 128

### DIFF
--- a/api/MessagesListAdapter/implementation.js
+++ b/api/MessagesListAdapter/implementation.js
@@ -1,10 +1,9 @@
 "use strict";
 
+/* globals ExtensionCommon, Services */
+
 // Using a closure to not leak anything but the API to the outside world.
 (function (exports) {
-
-  // Get various parts of the WebExtension framework that we need.
-  var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
 
   const listenerThreadPanes = new Set();
   const messageListListener = new ExtensionCommon.EventEmitter();

--- a/manifest.json
+++ b/manifest.json
@@ -3,12 +3,12 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "9",
+  "version": "10",
   "applications": {
     "gecko": {
       "id": "quickfilterby@extensions.thunderbird.net",
       "strict_min_version": "115.0",
-      "strict_max_version": "118.*"
+      "strict_max_version": "131.*"
     }
   },
   "background": {


### PR DESCRIPTION
There is not much which needs to be changed.

`ChromeUtils.import(*.jsm)` has been replaced by `ChromeUtils.importESModule(*.sys.mjs)`, but since `ExtensionCommon` is already globaly available, we can simply remove the import statement.

This will work in Thunderbird 115 as well.